### PR TITLE
Re-organize UI based on current usage & ideas

### DIFF
--- a/apps/elvis/web/elm/Channel/View.elm
+++ b/apps/elvis/web/elm/Channel/View.elm
@@ -235,17 +235,28 @@ playlist channel =
         entry rendition =
             Html.map (Channel.ModifyRendition rendition.id) (Rendition.View.playlist rendition)
 
-        playlist =
-            Maybe.withDefault [] (List.tail channel.playlist)
+        (current, playlist) =
+            case channel.playlist of
+                c :: r ->
+                    ( Just c, r )
 
-        panel =
-            case List.length playlist of
+                [] ->
+                    ( Nothing, [] )
+
+            -- Maybe.withDefault [] (List.tail channel.playlist)
+
+        list =
+            case List.length channel.playlist of
                 0 ->
                     div [ class "playlist__empty" ] [ text "Playlist empty" ]
 
                 _ ->
-                    div [ class "block-group playlist" ]
-                        (List.map entry playlist)
+                    div
+                        [ class "channel--playlist--entries" ]
+                        [ div [ class "channel--playlist--head" ] [ (playlistHead channel current) ]
+                        , playlistDivision "Queued"
+                        , div [ class "channel--playlist--tail" ] (List.map entry playlist)
+                        ]
 
         actionButtons =
             case List.length playlist of
@@ -263,11 +274,29 @@ playlist channel =
                     ]
     in
         div [ id "__scrolling__", class "channel--playlist" ]
-            [ div [ class "channel--playlist-actions" ]
-                actionButtons
-            , panel
+            [ div [ class "channel--playlist-actions" ] actionButtons
+            , list
             ]
 
+
+playlistHead : Channel.Model -> Maybe Rendition.Model -> Html Channel.Msg
+playlistHead channel maybeRendition =
+    case maybeRendition of
+        Nothing ->
+            div [] []
+
+        Just rendition ->
+            div
+                []
+                [ playlistDivision "Currently playing"
+                , Html.map (Channel.ModifyRendition rendition.id) (Rendition.View.playlistHead rendition)
+                ]
+
+
+
+playlistDivision : String -> Html Channel.Msg
+playlistDivision title =
+    div [ class "channel--playlist-division" ] [ text title ]
 
 mapTap : Attribute (Utils.Touch.E Channel.Msg) -> Attribute Channel.Msg
 mapTap a =

--- a/apps/elvis/web/elm/Msg.elm
+++ b/apps/elvis/web/elm/Msg.elm
@@ -30,6 +30,7 @@ type Msg
     | SingleTouch (Utils.Touch.E Msg)
     | ActivateView State.ViewMode
     | ToggleShowChannelControl
+    | ToggleShowChannelSelector
     | ReceiverAttachmentChange
     -- application settings
     | LoadApplicationSettings String Settings.Model

--- a/apps/elvis/web/elm/Rendition/View.elm
+++ b/apps/elvis/web/elm/Rendition/View.elm
@@ -215,6 +215,8 @@ playlist rendition =
                         , text ", "
                         , text (renditionAlbum rendition)
                         ]
+                    , div [ class "playlist--entry--duration" ]
+                        [ text (Source.View.duration source) ]
                     ]
                 , div
                     [ class "playlist--entry--skip"
@@ -226,6 +228,42 @@ playlist rendition =
             , div
                 [ class "playlist--entry--menu" ]
                 menu
+            ]
+
+
+playlistHead : Rendition.Model -> Html Rendition.Msg
+playlistHead rendition =
+    let
+        source =
+            rendition.source
+
+        coverImage =
+            source.cover_image
+
+    in
+        div
+            [ classList
+                [ ( "playlist--entry", True )
+                , ( "playlist--entry__head", True )
+                ]
+            ]
+            [ div
+                [ class "playlist--entry--contents"
+                ]
+                [ div [ class "playlist--entry--image", style [ ( "backgroundImage", "url(" ++ coverImage ++ ")" ) ] ] []
+                , div [ class "playlist--entry--inner" ]
+                    [ div [ class "playlist--entry--title" ]
+                        [ strong [] [ text (renditionTitle rendition) ] ]
+                    , div [ class "playlist--entry--album" ]
+                        [ strong []
+                            [ text (renditionPerformer rendition) ]
+                        , text ", "
+                        , text (renditionAlbum rendition)
+                        ]
+                    , div [ class "playlist--entry--duration" ]
+                        [ text (Source.View.duration source) ]
+                    ]
+                ]
             ]
 
 

--- a/apps/elvis/web/elm/Root.elm
+++ b/apps/elvis/web/elm/Root.elm
@@ -34,6 +34,7 @@ type alias Model =
     , touches : Utils.Touch.Model
     , animationTime : Maybe Time
     , notifications : List (Notification.Model Msg)
+    , showSelectChannel : Bool
     , viewMode : State.ViewMode
     , showChannelControl : Bool
     , savedState : Maybe SavedState

--- a/apps/elvis/web/elm/Root/State.elm
+++ b/apps/elvis/web/elm/Root/State.elm
@@ -42,6 +42,7 @@ initialState =
     , showChannelControl = True
     , savedState = Nothing
     , settings = Nothing
+    , showSelectChannel = False
     }
 
 
@@ -418,6 +419,9 @@ update action model =
                         |> Maybe.withDefault Cmd.none
             in
                 { model | settings = settings } ! [cmd]
+
+        Msg.ToggleShowChannelSelector ->
+            { model | showSelectChannel = not model.showSelectChannel } ! []
 
 
 

--- a/apps/elvis/web/elm/Root/View.elm
+++ b/apps/elvis/web/elm/Root/View.elm
@@ -55,11 +55,11 @@ rootWithActiveChannel : Root.Model -> Channel.Model -> Html Msg
 rootWithActiveChannel model channel =
     div
         [ id "root" ]
-        [ (activeRendition model channel)
+        [ (switchView model channel)
         , (notifications model)
         , (channelControl model channel)
         , (activeView model channel)
-        , (switchView model channel)
+        , (activeRendition model channel)
         ]
 
 activeRendition : Root.Model -> Channel.Model -> Html Msg

--- a/apps/elvis/web/elm/Root/View.elm
+++ b/apps/elvis/web/elm/Root/View.elm
@@ -58,6 +58,8 @@ rootWithActiveChannel model channel =
         , classList
             [ ("root--channel-select__active", model.showSelectChannel)
             , ("root--channel-select__inactive", not model.showSelectChannel)
+            , ("root--channel-control__active", model.showChannelControl)
+            , ("root--channel-control__inactive", not model.showChannelControl)
             ]
         ]
         [ (selectChannel model channel)

--- a/apps/elvis/web/elm/Root/View.elm
+++ b/apps/elvis/web/elm/Root/View.elm
@@ -72,7 +72,7 @@ selectChannel model channel =
             div [ class "root--channel-list" ]
                 [ div
                     []
-                    [ Channels.View.channel model channel ]
+                    [ Channels.View.channelSelector model channel ]
                 , div
                     [ class "root--channel-list-toggle"
                     , onClick (Msg.ToggleShowChannelSelector)
@@ -280,7 +280,7 @@ channelControl model channel =
                         (Msg.Channel channel.id)
                         (Channel.View.control model channel)
                       )
-                    , (receiverControl model channel)
+                    , Channels.View.channelReceivers model channel
                     -- padding
                     , (div [ style [("height", "30vh")] ] [])
                     ]
@@ -296,60 +296,3 @@ channelControl model channel =
             contents
 
 
-receiverControl : Root.Model -> Channel.Model -> Html Msg
-receiverControl model channel =
-    let
-        hideAttachMsg =
-            Msg.ShowAttachReceiver False
-
-        ( attached, detached ) =
-            Receiver.partitionReceivers channel model.receivers
-
-        contents =
-            case model.showAttachReceiver of
-                True ->
-                    Channels.View.detachedReceivers model channel
-
-                False ->
-                    Channels.View.channelReceivers model channel
-
-        showAttachMsg =
-            if List.isEmpty detached then
-                Msg.NoOp
-
-            else
-                Msg.ShowAttachReceiver True
-
-    in
-        div
-            [ class "root--receiver-control" ]
-            [ div
-                [ class "root--receiver-control-tabs" ]
-                [ div
-                    [ classList
-                        [ ("root--receiver-control-tab", True )
-                        , ("root--receiver-control-tab__active", not model.showAttachReceiver )
-                        , ("root--receiver-control--attached", True )
-                        ]
-                    , onClick hideAttachMsg
-                    , mapTouch (Utils.Touch.touchStart hideAttachMsg)
-                    , mapTouch (Utils.Touch.touchEnd hideAttachMsg)
-                    ]
-                    [ text ((toString (List.length attached)) ++ " Receivers")
-                    ]
-                , div
-                    [ classList
-                        [ ("root--receiver-control-tab", True )
-                        , ("root--receiver-control-tab__active", model.showAttachReceiver )
-                        , ("root--receiver-control--detached", True )
-                        , ("root--receiver-control-tab__disabled", (List.isEmpty detached) )
-                        ]
-                    , onClick showAttachMsg
-                    , mapTouch (Utils.Touch.touchStart showAttachMsg)
-                    , mapTouch (Utils.Touch.touchEnd showAttachMsg)
-                    ]
-                    [ text "Attach"
-                    ]
-                ]
-            , contents
-            ]

--- a/apps/elvis/web/elm/Root/View.elm
+++ b/apps/elvis/web/elm/Root/View.elm
@@ -54,7 +54,42 @@ rootWhenConnected model =
 rootWithActiveChannel : Root.Model -> Channel.Model -> Html Msg
 rootWithActiveChannel model channel =
     div
-        [ id "root" ]
+        [ id "root"
+        , classList
+            [ ("root--channel-select__active", model.showSelectChannel)
+            , ("root--channel-select__inactive", not model.showSelectChannel)
+            ]
+        ]
+        [ (selectChannel model channel)
+        , (channelView model channel)
+        ]
+
+
+selectChannel : Root.Model -> Channel.Model -> Html Msg
+selectChannel model channel =
+    case model.showSelectChannel of
+        True ->
+            div [ class "root--channel-list" ]
+                [ div
+                    []
+                    [ Channels.View.channel model channel ]
+                , div
+                    [ class "root--channel-list-toggle"
+                    , onClick (Msg.ToggleShowChannelSelector)
+                    , mapTouch (Utils.Touch.touchStart (Msg.ToggleShowChannelSelector))
+                    , mapTouch (Utils.Touch.touchEnd (Msg.ToggleShowChannelSelector))
+                    ]
+                    []
+                ]
+
+        False ->
+            div [ class "root--channel-list" ] []
+
+
+channelView : Root.Model -> Channel.Model -> Html Msg
+channelView model channel =
+    div
+        [ class "root--channel" ]
         [ (switchView model channel)
         , (notifications model)
         , (channelControl model channel)
@@ -150,9 +185,6 @@ activeView model channel =
                 State.ViewCurrentChannel ->
                     Html.map (Msg.Channel channel.id) (lazy Channel.View.playlist channel)
 
-                State.ViewChannelSwitch ->
-                    Channels.View.channel model channel
-
                 State.ViewLibrary ->
                     Html.map Msg.Library (Library.View.root model.library)
 
@@ -166,9 +198,26 @@ activeView model channel =
 
 switchView : Root.Model -> Channel.Model -> Html Msg
 switchView model channel =
-    div
-        [ class "root--switch-view" ]
-        (List.map (switchViewButton model channel) State.viewModes)
+    let
+        states =
+            (List.map (switchViewButton model channel) State.viewModes)
+
+        switchChannel =
+            div
+                [ classList
+                    [ ( "root--switch-view--btn", True )
+                    , ( "root--switch-view--btn__active", model.showSelectChannel )
+                    , ( "root--switch-view--btn__SelectChannel", True )
+                    ]
+                , onClick (Msg.ToggleShowChannelSelector)
+                , mapTouch (Utils.Touch.touchStart (Msg.ToggleShowChannelSelector))
+                , mapTouch (Utils.Touch.touchEnd (Msg.ToggleShowChannelSelector))
+                ]
+                [ text "Channels" ]
+    in
+        div
+            [ class "root--switch-view" ]
+            (switchChannel :: states)
 
 
 playlistDuration : Channel.Model -> Html Msg

--- a/apps/elvis/web/elm/Root/View.elm
+++ b/apps/elvis/web/elm/Root/View.elm
@@ -92,7 +92,7 @@ channelView model channel =
         [ class "root--channel" ]
         [ (switchView model channel)
         , (notifications model)
-        , (channelControl model channel)
+        -- , (channelControl model channel)
         , (activeView model channel)
         , (activeRendition model channel)
         ]
@@ -127,10 +127,29 @@ activeRendition model channel =
                         rendition
                         channel.playing
 
+        control =
+            if model.showChannelControl then
+                (channelControl model channel)
+            else
+                div [] []
     in
-        div [ class "root--active-rendition" ]
-            [ (rendition model channel)
-            , Html.map (Msg.Channel channel.id) progress
+        div
+            [ classList
+                [ ("root--channel-control-bar", True)
+                , ("root--channel-control-bar__inactive", not model.showChannelControl)
+                , ("root--channel-control-bar__active", model.showChannelControl)
+                ]
+            ]
+            [
+                div
+                    [ class "root--channel-control-position" ]
+                    [ div
+                        [ class "root--active-rendition" ]
+                        [ (rendition model channel)
+                        , Html.map (Msg.Channel channel.id) progress
+                        ]
+                    , control
+                    ]
             ]
 
 

--- a/apps/elvis/web/elm/State.elm
+++ b/apps/elvis/web/elm/State.elm
@@ -51,9 +51,9 @@ viewLabel mode =
 
 viewModes : List ViewMode
 viewModes =
-    [ ViewCurrentChannel
+    [ ViewChannelSwitch
+    , ViewCurrentChannel
     , ViewLibrary
-    , ViewChannelSwitch
     , ViewSettings
     ]
 

--- a/apps/elvis/web/elm/State.elm
+++ b/apps/elvis/web/elm/State.elm
@@ -25,7 +25,6 @@ type ChannelListMode
 
 type ViewMode
     = ViewCurrentChannel
-    | ViewChannelSwitch
     | ViewLibrary
     | ViewSettings
 
@@ -40,9 +39,6 @@ viewLabel mode =
         ViewCurrentChannel ->
             "Playlist"
 
-        ViewChannelSwitch ->
-            "Channels"
-
         ViewLibrary ->
             "Library"
 
@@ -51,8 +47,7 @@ viewLabel mode =
 
 viewModes : List ViewMode
 viewModes =
-    [ ViewChannelSwitch
-    , ViewCurrentChannel
+    [ ViewCurrentChannel
     , ViewLibrary
     , ViewSettings
     ]
@@ -68,9 +63,6 @@ deserialiseViewMode modeString =
     case modeString of
         "ViewCurrentChannel" ->
             ViewCurrentChannel
-
-        "ViewChannelSwitch" ->
-            ViewChannelSwitch
 
         "ViewLibrary" ->
             ViewLibrary

--- a/apps/elvis/web/static/css/components/channel.css
+++ b/apps/elvis/web/static/css/components/channel.css
@@ -51,23 +51,40 @@
 }
 
 .channel--info--name {
+  padding-top: 2px;
   height: $active-channel-bar-height;
+  box-sizing: border-box;
   text-transform: uppercase;
   font-weight: 700;
   font-size: 1.2rem;
   line-height: $active-channel-bar-height;
   color: #E65100;
   position: relative;
+  display: flex;
+  align-items: center;
 }
 .channel--info--name .channel--name {
-  position: absolute;
-  bottom: -1px;
+  /* position: absolute; */
+  /* bottom: -1px; */
   line-height: 0;
 }
 
 .channel--info--name .channel--playlist-duration {
 	color: #BF360C;
 }
+
+$active-channel-multiplier: 1.7;
+
+.root--channel-control__active .channel--info--name {
+  padding-top: 0;
+  height: calc($active-channel-bar-height * $active-channel-multiplier);
+  font-size: 1.4rem;
+  line-height: calc($active-channel-bar-height * $active-channel-multiplier);
+}
+.root--channel-control__active .channel--info--name .channel--name:before {
+  line-height: 0;
+}
+
 .channel--control {
 	color: #fff;
 }
@@ -75,16 +92,18 @@
 .channel--rewind-play-skip {
 	display: flex;
 	flex-direction: row;
-	margin: calc($button-size / 2) calc($button-size / 2) 0;
+	margin: 0 calc($button-size / 2) 0 calc($button-size / 2);
 }
+
+$cover-size: 60vw;
 
 .channel--rendition-cover {
 	margin: 0 0 calc($button-size / 2) 0;
 	/* background-color: rgba(255, 255, 255, 0.6); */
 	background-repeat: no-repeat;
 	background-position: center center;
-	background-size: calc(100vw) auto;
-	height: 100vw;
+	background-size: $cover-size auto;
+	height: calc($cover-size + (2 * $button-size));
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -129,8 +148,9 @@
 
 
 .channel--rendition-progress {
-  margin: 0;
+  /* margin: 0; */
 	/* margin: 0 calc($button-size / 2) 0 calc($button-size / 2); */
+	margin: calc($button-size / 4) 0 0 0;
 	height: calc($button-size / 2);
 	display: flex;
 	align-items: center;

--- a/apps/elvis/web/static/css/components/channel.css
+++ b/apps/elvis/web/static/css/components/channel.css
@@ -179,3 +179,13 @@ $cover-size: 60vw;
 }
 
 
+.channel--playlist-division {
+  height: calc($button-size / 2);
+  text-transform: uppercase;
+  font-size: 1.2rem;
+  line-height: calc($button-size / 2);
+  font-weight: 700;
+  padding: 0 $padding;
+  background: #ddd;
+  color: #444;
+}

--- a/apps/elvis/web/static/css/components/channels.css
+++ b/apps/elvis/web/static/css/components/channels.css
@@ -65,9 +65,9 @@ $channel-select-border: rgba(0, 0, 0, 0.05);
 
 .channels-selector--channel {
   /* flex: 0 0 $button-size; */
-  height: $button-size;
+  /* height: $button-size; */
   display: flex;
-  align-items: center;
+  flex-direction: column;
   /* color: #fff; */
   cursor: pointer;
   position: relative;
@@ -138,11 +138,11 @@ $channel-select-border: rgba(0, 0, 0, 0.05);
 .channels-selector--display {
   /* @mixin slideEditName; */
   height: $button-size;
-  flex: 0 0 calc($button-size);
+  /* flex: 0 0 calc($button-size); */
   display: flex;
   position: relative;
   z-index: 0;
-  flex: 1;
+  flex: 0 0 $button-size;
   align-items: center;
   /* color: #fff; */
   /* left: 0; */
@@ -295,6 +295,9 @@ $channel-select-border: rgba(0, 0, 0, 0.05);
   /* margin-top: calc($button-size / 2); */
 }
 
+.channels-selector--channel-attach-receivers {
+  background: rgba(0, 0, 0, 0.15);
+}
 @media (--desktop) {
   .channels {
     width: $channel-column-width;
@@ -307,5 +310,7 @@ $channel-select-border: rgba(0, 0, 0, 0.05);
     right: 0;
   }
 }
+
+
 
 

--- a/apps/elvis/web/static/css/components/channels.css
+++ b/apps/elvis/web/static/css/components/channels.css
@@ -50,7 +50,7 @@
 .channels--view {
 	/* color: #fff; */
 	/* background: #111; */
-	width: 100vw;
+	/* width: 100vw; */
 }
 .channels--toggle {
   width: $button-size;

--- a/apps/elvis/web/static/css/components/playlist.css
+++ b/apps/elvis/web/static/css/components/playlist.css
@@ -14,6 +14,9 @@
   cursor: pointer;
   position: relative;
 }
+.playlist--entry__head {
+  border-bottom: none;
+}
 
 .playlist--entry--image {
   width: $button-size;
@@ -37,6 +40,11 @@
 }
 .playlist--entry--album {
   color: #999;
+}
+.playlist--entry--duration {
+  color: #999;
+  font-size: 0.9em;
+  font-weight: 500;
 }
 .playlist--entry--skip {
   @mixin fa-btn "\f050";  /* play */

--- a/apps/elvis/web/static/css/components/rendition.css
+++ b/apps/elvis/web/static/css/components/rendition.css
@@ -41,23 +41,6 @@
   cursor: pointer;
 }
 
-.rendition--meta {
-  /* text-overflow: ellipsis; */
-  max-width: calc(100vw - 2 * ($button-size + $padding));
-  overflow: hidden;
-  white-space: nowrap;
-  font-size: 1.4rem;
-  font-weight: 100;
-  /* flex: 1; */
-  /* min-width: 0; */
-  text-overflow: ellipsis; overflow: hidden;
-}
-
-.rendition--meta--detail  {
-  display: inline;
-  white-space: nowrap;
-  min-width: 0;
-}
 .rendition--title {
   /* @mixin h2; */
   /* @mixin fa-btn "\f04b"; */
@@ -161,18 +144,37 @@
   flex-direction: column;
   align-items: stretch;
   padding-left: $padding;
+  font-size: 1.6rem;
+  line-height: 1.2;
 }
 
 .rendition--details--top {
   @mixin h2;
-  font-size: 1.6rem;
-  padding-top: calc($padding / 2);
-  line-height: 110%;
+  font-size: 1em;
+  /* padding-top: calc($padding / 2); */
   /* padding-left: $padding; */
   /* display: flex; */
   /* align-items: baseline; */
   /* flex: 1; */
 
+}
+
+.rendition--meta {
+  /* text-overflow: ellipsis; */
+  max-width: calc(100vw - 2 * ($button-size + $padding));
+  overflow: hidden;
+  white-space: nowrap;
+  font-size: 0.8em;
+  font-weight: 100;
+  /* flex: 1; */
+  /* min-width: 0; */
+  text-overflow: ellipsis; overflow: hidden;
+}
+
+.rendition--meta--detail  {
+  display: inline;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .rendition--progress {
@@ -202,5 +204,9 @@
   height: calc($button-size - 6);
   margin: 3px;
   display: block;
+}
+
+.root--channel-control__active .rendition--details {
+  font-size: 2rem;
 }
 

--- a/apps/elvis/web/static/css/components/root.css
+++ b/apps/elvis/web/static/css/components/root.css
@@ -159,9 +159,38 @@
 
 
 /* ******* */
+$active-channel-peek-width: calc(1.5 * $button-size);
 
 #root {
 	display: flex;
+	height: 100vh;
+	max-height: 100vh;
+	flex-direction: row;
+}
+
+#root > .root--channel-list {
+	/* transition: flex-basis 1s; */
+}
+#root.root--channel-select__inactive > .root--channel-list {
+	flex: 0 0 0;
+}
+#root.root--channel-select__active > .root--channel-list {
+	flex: 0 0 calc(100vw - $active-channel-peek-width);
+}
+
+.root--channel-list-toggle {
+	position: absolute;
+	right: 0;
+	top: $button-size;
+	bottom: 0;
+	width: $active-channel-peek-width;
+	background-color: rgba(0, 0, 0, 0.5);
+	z-index: 10000;
+}
+
+.root--channel {
+	display: flex;
+	width: 100vw;
 	height: 100vh;
 	max-height: 100vh;
 	flex-direction: column;
@@ -187,7 +216,7 @@
 
 .root--switch-view {
 	background: rgba(66, 66, 66, 1);
-	flex: 0 0 60px;
+	flex: 0 0 $button-size;
 	display: flex;
 	flex-direction: row;
 	align-items: stretch;
@@ -198,7 +227,7 @@
 .root--switch-view--btn {
 	flex: 1;
 	text-align: center;
-	margin: 0 2px;
+	margin: 0;
 	background: rgba(0, 0, 0, 0.1);
 	display: flex;
 	align-items: center;
@@ -281,4 +310,8 @@
 }
 .root--receiver-control-tab__disabled {
 	color: #999;
+}
+
+.root--switch-view--btn__SelectChannel {
+	flex: 0 0 $active-channel-peek-width;
 }

--- a/apps/elvis/web/static/css/components/root.css
+++ b/apps/elvis/web/static/css/components/root.css
@@ -304,3 +304,7 @@ $active-channel-peek-width: calc(1.5 * $button-size);
 .root--switch-view--btn__SelectChannel {
 	flex: 0 0 $active-channel-peek-width;
 }
+
+.root--channel-control__active .root--active-rendition {
+	flex: 0;
+}

--- a/apps/elvis/web/static/css/components/root.css
+++ b/apps/elvis/web/static/css/components/root.css
@@ -196,13 +196,6 @@ $active-channel-peek-width: calc(1.5 * $button-size);
 	flex-direction: column;
 }
 
-.root--active-rendition {
-	/* background: orange; */
-  color: #fff;
-  background: #000;
-	flex: 0 0 $button-size;
-}
-
 .root--active-view {
 	flex: 1;
 	max-width: 100vw;
@@ -237,15 +230,11 @@ $active-channel-peek-width: calc(1.5 * $button-size);
 
 }
 .root--switch-view--btn:hover {
-	background: rgba(255, 255, 255, 0.7);
+	/* background: rgba(255, 255, 255, 0.7); */
 }
 
 .root--switch-view--btn__active {
 	background: rgba(255, 0, 0, 0.8) !important;
-}
-.root--active-rendition {
-	display: flex;
-	flex-direction: row;
 }
 
 .root--switch-view--btn .channel--playlist-duration {
@@ -257,14 +246,40 @@ $active-channel-peek-width: calc(1.5 * $button-size);
 }
 
 /* channel control */
+.root--active-rendition {
+	/* background: orange; */
+  color: #fff;
+  background: #000;
+	flex: 0 0 $button-size;
+	display: flex;
+	flex-direction: row;
+}
+
+
+.root--channel-control-bar {
+	/* position: relative; */
+}
+.root--channel-control-bar__inactive {
+	position: relative;
+	height: $button-size;
+}
+.root--channel-control-bar__inactive .root--channel-control-position {
+	top: 0;
+}
+.root--channel-control-bar__active .root--channel-control-position {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100vw;
+	height: 100vh;
+}
 
 .root--channel-control {
 	display: flex;
 	height: 0;
 	opacity: 0;
-	background: rgba(0, 0, 0, 0.9);
+	background: rgba(0, 0, 0, 1);
 	transition: opacity 300ms;
-	position: fixed;
   top: 0;
 	bottom: $button-size;
 	right: 0;
@@ -284,32 +299,6 @@ $active-channel-peek-width: calc(1.5 * $button-size);
 
 .root--receiver-control  {
 	/* margin-top: calc($button-size / 2); */
-}
-.root--receiver-control-tabs {
-	display: flex;
-	flex-direction: row;
-	justify-content: center;
-	height: $button-size;
-	align-items: center;
-  margin: calc($button-size / 2) 0;
-}
-
-.root--receiver-control-tab {
-	flex: 0 0 50vw;
-	text-align: center;
-	background: #333;
-	height: calc($button-size / 1);
-	display: flex;
-	align-items: center;
-	text-align: center;
-	justify-content: center;
-}
-.root--receiver-control-tab__active {
-	font-weight: bold;
-	background: #ccc;
-}
-.root--receiver-control-tab__disabled {
-	color: #999;
 }
 
 .root--switch-view--btn__SelectChannel {

--- a/apps/elvis/web/static/css/components/root.css
+++ b/apps/elvis/web/static/css/components/root.css
@@ -234,9 +234,10 @@
 	height: 0;
 	opacity: 0;
 	background: rgba(0, 0, 0, 0.9);
-	transition: height 200ms, opacity 300ms;
+	transition: opacity 300ms;
 	position: fixed;
-	top: $button-size;
+  top: 0;
+	bottom: $button-size;
 	right: 0;
 	left: 0;
 	z-index: 1000000;
@@ -247,8 +248,8 @@
 
 .root--channel-control__active {
 	flex-direction: column;
-	height: calc(100vh - (2 * $button-size));
-	transition: height 200ms, opacity 300ms;
+	height: calc(100vh - (1 * $button-size));
+	transition: opacity 300ms;
 	opacity: 1;
 }
 

--- a/apps/elvis/web/static/js/app.js
+++ b/apps/elvis/web/static/js/app.js
@@ -206,6 +206,7 @@ app.ports.blurActiveElement.subscribe(blur => {
 })
 
 app.ports.settingsRequests.subscribe(app => {
+  channel.push("retrieve_settings", app)
   .receive("error", payload => console.log(payload.message))
 })
 

--- a/apps/otis_library/test/otis_library_test.exs
+++ b/apps/otis_library/test/otis_library_test.exs
@@ -1,8 +1,5 @@
 defmodule OtisLibraryTest do
   use ExUnit.Case
-  doctest OtisLibrary
+  doctest Otis.Library
 
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
 end


### PR DESCRIPTION
In particular:

- Move mini-player/rendition view to the bottom
  This makes opening the volume control much easier

- Move channel switcher into separate side-drawer view
  Which feels more natural as all other actions are per-channel

- Move receiver attachment to channel list
  This makes flow of switching to new channel easier & massively simplifies
  the active channel view (to just player & volume controls)

- Tweak other UI elements