### PR TITLE
Re-factor to handle async event handling

### DIFF
--- a/apps/elvis/lib/elvis/events/broadcast.ex
+++ b/apps/elvis/lib/elvis/events/broadcast.ex
@@ -102,9 +102,9 @@ defmodule Elvis.Events.Broadcast do
     {:ok, state}
   end
 
-  def handle_event({:receiver_connected, [receiver_id, _receiver]}, state) do
+  def handle_event({:receiver_online, [receiver_id, _receiver]}, state) do
     receiver_state = Otis.State.Receiver.find(receiver_id)
-    broadcast!(to_string(:receiver_connected), Otis.State.status(receiver_state))
+    broadcast!(to_string(:receiver_online), Otis.State.status(receiver_state))
     {:ok, state}
   end
 

--- a/apps/elvis/web/static/js/app.js
+++ b/apps/elvis/web/static/js/app.js
@@ -60,8 +60,8 @@ channel.on('receiver_removed', payload => {
   app.ports.receiverStatus.send(['receiver_removed', payload])
 })
 
-channel.on('receiver_connected', payload => {
-  console.log('receiver_connected', payload)
+channel.on('receiver_online', payload => {
+  console.log('receiver_online', payload)
   app.ports.receiverPresence.send(payload)
 })
 

--- a/apps/otis/lib/otis/events.ex
+++ b/apps/otis/lib/otis/events.ex
@@ -30,12 +30,10 @@ defmodule Otis.Events do
   end
 
   def handle_call({:notify, event}, _from, state) do
-    Logger.debug "EVENT #{__MODULE__}"
     {:reply, :ok, [event], state}
   end
 
   def handle_cast({:notify, event}, state) do
-    Logger.debug "EVENT #{__MODULE__}"
     {:noreply, [event], state}
   end
 end

--- a/apps/otis/lib/otis/pipeline/broadcaster.ex
+++ b/apps/otis/lib/otis/pipeline/broadcaster.ex
@@ -66,9 +66,8 @@ defmodule Otis.Pipeline.Broadcaster do
   def handle_info({:receiver_joined, [_id, receiver]}, state) do
     {:ok, time} = Clock.time(state.clock)
     playable = playable_packets(time, state)
-    data = Enum.map(playable, &Packet.marshal/1)
     Receiver.stop(receiver)
-    Receiver.send_data(receiver, data)
+    Receiver.send_packets(receiver, playable)
     {:noreply, state}
   end
 
@@ -208,8 +207,7 @@ defmodule Otis.Pipeline.Broadcaster do
   end
 
   defp broadcast_packets({state, packets}) do
-    data = Enum.map(packets, &Packet.marshal/1)
-    Otis.Receivers.Channels.send_data(state.id, data)
+    Otis.Receivers.Channels.send_packets(state.id, packets)
     {state, packets}
   end
 

--- a/apps/otis/lib/otis/receiver.ex
+++ b/apps/otis/lib/otis/receiver.ex
@@ -235,6 +235,7 @@ defmodule Otis.Receiver do
   """
   def join_channel(receiver, channel) do
     Otis.Receivers.Channels.add_receiver(receiver, channel)
+    Otis.Events.notify({:receiver_online, [receiver.id, receiver]})
   end
 
   @doc ~S"""

--- a/apps/otis/lib/otis/receiver.ex
+++ b/apps/otis/lib/otis/receiver.ex
@@ -281,6 +281,12 @@ defmodule Otis.Receiver do
     {:ok, addr}
   end
 
+  def send_packets(%R{data: {pid, _socket}}, packets) do
+    GenServer.cast(pid, {:packets, packets})
+  end
+  def send_packets(%R{data: nil}, _packets) do
+  end
+
   def send_data(%{data: {pid, _socket}}, data) do
     GenServer.cast(pid, {:data, data})
   end

--- a/apps/otis/lib/otis/receivers/channels.ex
+++ b/apps/otis/lib/otis/receivers/channels.ex
@@ -47,6 +47,12 @@ defmodule Otis.Receivers.Channels do
     notify_subscribers(receiver, channel, :receiver_left)
   end
 
+  def send_packets(channel_id, packets) do
+    Enum.each(lookup(channel_id), fn(r) ->
+      Receiver.send_packets(r, packets)
+    end)
+  end
+
   def send_data(channel_id, data) do
     Enum.each(lookup(channel_id), fn(r) ->
       Receiver.send_data(r, data)

--- a/apps/otis/lib/otis/receivers/control_connection.ex
+++ b/apps/otis/lib/otis/receivers/control_connection.ex
@@ -52,6 +52,9 @@ defmodule Otis.Receivers.ControlConnection do
     %{configure: settings} |> send_command(state)
     {:noreply, state}
   end
+  def handle_cast(:start, state) do
+    {:noreply, state}
+  end
 
   def handle_call(:get_volume, _from, state) do
     {:reply, Map.fetch(state.settings, :volume), state}

--- a/apps/otis/lib/otis/receivers/protocol.ex
+++ b/apps/otis/lib/otis/receivers/protocol.ex
@@ -6,7 +6,7 @@ defmodule Otis.Receivers.Protocol do
       require Logger
 
       defmodule S do
-        defstruct [:socket, :transport, :id, :supervisor, :settings, :monitor_timeout, muted: false]
+        defstruct [:socket, :transport, :id, :supervisor, :settings, :monitor_timeout, muted: false, progress: {"", 0}]
       end
 
       def start_link(ref, socket, transport, opts) do
@@ -24,7 +24,7 @@ defmodule Otis.Receivers.Protocol do
           supervisor: opts[:supervisor],
           settings: initial_settings(),
         }
-        state = state |> monitor_connection
+        state = state |> start |> monitor_connection
         :gen_server.enter_loop(__MODULE__, [], state)
       end
 
@@ -54,6 +54,11 @@ defmodule Otis.Receivers.Protocol do
 
       def handle_info(:ping, state) do
         send_ping(state)
+      end
+
+      defp start(state) do
+        GenServer.cast(self(), :start)
+        state
       end
 
       def process_message({_id, %{"pong" => _pong}}, state) do

--- a/apps/otis/lib/otis/state/persistence/renditions.ex
+++ b/apps/otis/lib/otis/state/persistence/renditions.ex
@@ -51,9 +51,7 @@ defmodule Otis.State.Persistence.Renditions do
     {:ok, state}
   end
   def handle_event({:rendition_progress, [_channel_id, rendition_id, position, _duration]}, state) do
-    Repo.transaction fn ->
-      rendition_id |> load_rendition |> rendition_progress(rendition_id, position)
-    end
+    :ok = Otis.State.RenditionProgress.update(rendition_id, position)
     {:ok, state}
   end
   def handle_event(_evt, state) do
@@ -111,14 +109,6 @@ defmodule Otis.State.Persistence.Renditions do
   defp renditions_deleted([rendition | renditions], channel_id) do
     rendition |> Rendition.delete!
     renditions_deleted(renditions, channel_id)
-  end
-
-  defp rendition_progress(nil, id, position) do
-    Logger.warn "Progress event for unknown rendition #{ inspect id } (#{ position })"
-    nil
-  end
-  defp rendition_progress(rendition, _id, position) do
-    Rendition.playback_position(rendition, position)
   end
 
   defp notify(rendition, event) do

--- a/apps/otis/lib/otis/state/rendition_progress.ex
+++ b/apps/otis/lib/otis/state/rendition_progress.ex
@@ -1,0 +1,63 @@
+defmodule Otis.State.RenditionProgress do
+  use GenServer
+
+  alias Otis.State.Repo
+
+  require Logger
+
+  @name __MODULE__
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: @name)
+  end
+
+  def update(rendition_id, progress) do
+    GenServer.call(@name, {:progress, rendition_id, progress})
+  end
+
+  def init(_opts) do
+    schedule()
+    Process.flag(:trap_exit, true)
+    {:ok, %{}}
+  end
+
+  def handle_call({:progress, rendition_id, progress}, _from, state) do
+    {:reply, :ok, Map.put(state, rendition_id, progress)}
+  end
+  def handle_call(:save, _from, state) do
+    save(state)
+    {:reply, :ok, %{}}
+  end
+
+  def handle_info(:flush, state) when state == %{} do
+    schedule()
+    {:noreply, %{}}
+  end
+  def handle_info(:flush, state) do
+    save(state)
+    schedule()
+    {:noreply, %{}}
+  end
+
+  def terminate(_reason, state) do
+    save(state)
+    :ok
+  end
+
+  defp schedule do
+    Process.send_after(self(), :flush, 1_000)
+  end
+
+  defp save(state) do
+    Repo.transaction fn ->
+      Enum.each(state, &save_progress/1)
+    end
+  end
+
+  @update_query  "UPDATE OR IGNORE renditions SET playback_position = $1 WHERE id = $2"
+
+  defp save_progress({rendition_id, position}) do
+    {:ok, id} = Ecto.UUID.dump(rendition_id)
+    Ecto.Adapters.SQL.query!(Repo, @update_query, [position, id])
+  end
+end

--- a/apps/otis/lib/otis/supervisor.ex
+++ b/apps/otis/lib/otis/supervisor.ex
@@ -15,6 +15,7 @@ defmodule Otis.Supervisor do
       worker(Otis.State.Repo, []),
       worker(Otis.Events, []),
       worker(Otis.LoggerHandler, []),
+      worker(Otis.State.RenditionProgress, []),
       worker(Otis.State.Persistence.Channels, []),
       worker(Otis.State.Persistence.Receivers, []),
       worker(Otis.State.Persistence.Renditions, []),

--- a/apps/otis/test/otis/pipeline/playlist_test.exs
+++ b/apps/otis/test/otis/pipeline/playlist_test.exs
@@ -167,7 +167,7 @@ defmodule Test.Otis.Pipeline.Playlist do
     [s1, _, _, _] = context.sources
     {:ok, pl} = Playlist.start_link(channel_id)
     :ok = Playlist.append(pl, s1)
-    assert_receive {:new_rendition_created, _}
+    assert_receive {:new_rendition_created, _}, 500
     {:ok, _} = Playlist.next(pl)
     :done = Playlist.next(pl)
     assert {:ok, []} == Playlist.list(pl)

--- a/apps/otis/test/otis/pipeline/transcoder_test.exs
+++ b/apps/otis/test/otis/pipeline/transcoder_test.exs
@@ -42,6 +42,6 @@ defmodule Test.Otis.Pipeline.Transcoder do
 
     assert byte_size(data) == 133632
     md5 = :crypto.hash_final(hash) |> Base.encode16(case: :lower)
-    assert md5 == "ba5a1791d3a00ac3ec31f2fe490a90c5"
+    assert md5 == "78e5aab4079be68850808d4bfe9f1101"
   end
 end

--- a/apps/otis/test/test_helper.exs
+++ b/apps/otis/test/test_helper.exs
@@ -193,7 +193,7 @@ defimpl Otis.Library.Source, for: Otis.Test.TestSource do
   end
 
   def transcoder_args(_track) do
-    []
+    # noop
   end
 
   def metadata(_track) do
@@ -320,7 +320,7 @@ defimpl Otis.Library.Source, for: Test.CycleSource do
   end
 
   def transcoder_args(_source) do
-    ["-f", "raw"]
+    :passthrough
   end
 
   def metadata(_source) do

--- a/apps/otis/test/test_helper.exs
+++ b/apps/otis/test/test_helper.exs
@@ -193,7 +193,7 @@ defimpl Otis.Library.Source, for: Otis.Test.TestSource do
   end
 
   def transcoder_args(_track) do
-    # noop
+    []
   end
 
   def metadata(_track) do


### PR DESCRIPTION
GenEvent driven events had some (albeit non-deterministic) ordering but the
GenStage powered version has none.